### PR TITLE
Fix diff drive model + add unit test

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/planar_joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/planar_joint_model.h
@@ -82,6 +82,16 @@ public:
     angular_distance_weight_ = weight;
   }
 
+  double getMinTranslationalDistance() const
+  {
+    return min_translational_distance_;
+  }
+
+  void setMinTranslationalDistance(double min_translational_distance)
+  {
+    min_translational_distance_ = min_translational_distance;
+  }
+
   MotionModel getMotionModel() const
   {
     return motion_model_;
@@ -100,19 +110,24 @@ public:
 private:
   double angular_distance_weight_;
   MotionModel motion_model_;
+  /// Only used for the differential drive motion model @see computeTurnDriveTurnGeometry
+  double min_translational_distance_;
 };
 
 /**
  * @brief Compute the geometry to turn toward the target point, drive straight and then turn to target orientation
- * @param[in]  from         A vector representing the initial position [x0, y0, theta0]
- * @param[in]  to           A vector representing the target position  [x1, y1, theta1]
- * @param[out] dx           x1 - x0 (meters)
- * @param[out] dy           y1 - y0 (meters)
- * @param[out] initial_turn The initial turn in radians to face the target
- * @param[out] drive_angle  The orientation in radians that the robot will be driving straight at
- * @param[out] final_turn   The final turn in radians to the target orientation
+ * @param[in]  from                       A vector representing the initial position [x0, y0, theta0]
+ * @param[in]  to                         A vector representing the target position  [x1, y1, theta1]
+ * @param[in]  min_translational_distance If the translational distance between \p from and \p to is less than this
+ *                                        value the motion will be pure rotation
+ * @param[out] dx                         x1 - x0 (meters)
+ * @param[out] dy                         y1 - y0 (meters)
+ * @param[out] initial_turn               The initial turn in radians to face the target
+ * @param[out] drive_angle                The orientation in radians that the robot will be driving straight at
+ * @param[out] final_turn                 The final turn in radians to the target orientation
  */
-void computeTurnDriveTurnGeometry(const double* from, const double* to, double& dx, double& dy, double& initial_turn,
-                                  double& drive_angle, double& final_turn);
+void computeTurnDriveTurnGeometry(const double* from, const double* to, const double min_translational_distance,
+                                  double& dx, double& dy, double& initial_turn, double& drive_angle,
+                                  double& final_turn);
 }  // namespace core
 }  // namespace moveit

--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -146,6 +146,15 @@ void computeTurnDriveTurnGeometry(const double* from, const double* to, double& 
 {
   dx = to[0] - from[0];
   dy = to[1] - from[1];
+  // If the translational distance between from & to states is very small, it will cause an unnecessary rotations since
+  // the robot will try to do the following rather than rotating directly to the orientation of `to` state
+  // 1- Align itself with the line connecting the origin of both states
+  // 2- Move to the origin of `to` state
+  // 3- Rotate so it have the same orientation as `to` state
+  // Example: from=[0.0, 0.0, 0.0] - to=[1e-31, 1e-31, -130°]
+  // here the robot will: rotate 45° -> move to the origin of `to` state -> rotate -175°, rather than rotating directly
+  // to -130°
+  // to fix this we added a magic number 0.01 and make the movement pure rotation if the translational distance is less than this number
   const double angle_straight_diff =
       std::hypot(dx, dy) > 0.01 ? angles::shortest_angular_distance(from[2], std::atan2(dy, dx)) : 0.0;
   const double angle_backward_diff =

--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -244,12 +244,6 @@ double PlanarJointModel::distance(const double* values1, const double* values2) 
   }
   else if (motion_model_ == DIFF_DRIVE)
   {
-    // Shortcut to avoid extraneous calculations
-    if (values1[0] == values2[0] && values1[1] == values2[1] && values1[2] == values2[2])
-    {
-      return 0.0;
-    }
-
     double dx, dy, initial_turn, drive_angle, final_turn;
     computeTurnDriveTurnGeometry(values1, values2, dx, dy, initial_turn, drive_angle, final_turn);
     return hypot(dx, dy) + angular_distance_weight_ * (fabs(initial_turn) + fabs(final_turn));

--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -148,7 +148,8 @@ void computeTurnDriveTurnGeometry(const double* from, const double* to, double& 
   dy = to[1] - from[1];
   const double angle_straight_diff =
       std::hypot(dx, dy) > 0.01 ? angles::shortest_angular_distance(from[2], std::atan2(dy, dx)) : 0.0;
-  const double angle_backward_diff = angles::normalize_angle(angle_straight_diff - M_PI);
+  const double angle_backward_diff =
+      angles::normalize_angle(angle_straight_diff - boost::math::constants::pi<double>());
   const double move_straight_cost =
       std::abs(angle_straight_diff) + std::abs(angles::shortest_angular_distance(from[2] + angle_straight_diff, to[2]));
   const double move_backward_cost =

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1043,6 +1043,36 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
 
         ((PlanarJointModel*)new_joint_model)->setMotionModel(motion_model);
       }
+      else if (property.property_name_ == "min_translational_distance")
+      {
+        if (new_joint_model->getType() != JointModel::JointType::PLANAR)
+        {
+          RCLCPP_ERROR(LOGGER, "Cannot apply property %s to joint type: %s", property.property_name_.c_str(),
+                       new_joint_model->getTypeName().c_str());
+          continue;
+        }
+        double min_translational_distance;
+        try
+        {
+          std::string::size_type sz;
+          min_translational_distance = std::stod(property.value_, &sz);
+          if (sz != property.value_.size())
+          {
+            RCLCPP_WARN_STREAM(LOGGER, "Extra characters after property " << property.property_name_ << " for joint "
+                                                                          << property.joint_name_ << " as double: '"
+                                                                          << property.value_.substr(sz) << "'");
+          }
+        }
+        catch (const std::invalid_argument& e)
+        {
+          RCLCPP_ERROR_STREAM(LOGGER, "Unable to parse property " << property.property_name_ << " for joint "
+                                                                  << property.joint_name_ << " as double: '"
+                                                                  << property.value_ << "'");
+          continue;
+        }
+
+        ((PlanarJointModel*)new_joint_model)->setMinTranslationalDistance(min_translational_distance);
+      }
       else
       {
         RCLCPP_ERROR(LOGGER, "Unknown joint property: %s", property.property_name_.c_str());

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -169,6 +169,13 @@ public:
   void addEndEffector(const std::string& name, const std::string& parent_link, const std::string& parent_group = "",
                       const std::string& component_group = "");
 
+  /** \brief Adds a new joint property
+   *  \param[in] joint_name The name of the joint the property is specified for
+   *  \param[in] property_name The joint property name
+   *  \param[in] value The value of the joint property
+   */
+  void addJointProperty(const std::string& joint_name, const std::string& property_name, const std::string& value);
+
   /** \} */
 
   /** \brief Returns true if the building process so far has been valid. */

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -361,11 +361,7 @@ void RobotModelBuilder::addEndEffector(const std::string& name, const std::strin
 void RobotModelBuilder::addJointProperty(const std::string& joint_name, const std::string& property_name,
                                          const std::string& value)
 {
-  srdf::Model::JointProperty joint_property;
-  joint_property.joint_name_ = joint_name;
-  joint_property.property_name_ = property_name;
-  joint_property.value_ = value;
-  srdf_writer_->joint_properties_[joint_name].push_back(joint_property);
+  srdf_writer_->joint_properties_[joint_name].push_back({ joint_name, property_name, value });
 }
 
 bool RobotModelBuilder::isValid()

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -358,6 +358,16 @@ void RobotModelBuilder::addEndEffector(const std::string& name, const std::strin
   srdf_writer_->end_effectors_.push_back(eef);
 }
 
+void RobotModelBuilder::addJointProperty(const std::string& joint_name, const std::string& property_name,
+                                         const std::string& value)
+{
+  srdf::Model::JointProperty joint_property;
+  joint_property.joint_name_ = joint_name;
+  joint_property.property_name_ = property_name;
+  joint_property.value_ = value;
+  srdf_writer_->joint_properties_[joint_name].push_back(joint_property);
+}
+
 bool RobotModelBuilder::isValid()
 {
   return is_valid_;

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -185,6 +185,34 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
   joint_model_state_space.freeState(state);
 }
 
+// Run the OMPL sanity checks on the diff drive model
+TEST(TestDiffDrive, TestStateSpace)
+{
+  moveit::core::RobotModelBuilder builder("mobile_base", "base_link");
+  builder.addVirtualJoint("odom_combined", "base_link", "planar", "base_joint");
+  builder.addJointProperty("base_joint", "motion_model", "diff_drive");
+  builder.addGroup({}, {"base_joint"}, "base");
+  ASSERT_TRUE(builder.isValid());
+
+  auto robot_model = builder.build();
+  ompl_interface::ModelBasedStateSpaceSpecification spec(robot_model, "base");
+  ompl_interface::JointModelStateSpace ss(spec);
+  ss.setPlanningVolume(-2, 2, -2, 2, -2, 2);
+  ss.setup();
+
+  bool passed = false;
+  try
+  {
+    ss.sanityChecks();
+    passed = true;
+  }
+  catch (ompl::Exception& ex)
+  {
+    RCLCPP_ERROR(LOGGER, "Sanity checks did not pass: %s", ex.what());
+  }
+  EXPECT_TRUE(passed);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### Description

1- The previous model wasn't passing OMPL's sanityCheck so I update `computeTurnDriveTurnGeometry` to enable backward movement
2- Add unit test for testing the diff drive state space

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
